### PR TITLE
Make weather station elevation nullable

### DIFF
--- a/backend/DTOs/WeatherStationDto.cs
+++ b/backend/DTOs/WeatherStationDto.cs
@@ -7,7 +7,7 @@
         public string? Description { get; set; }
         public double Longitude { get; set; }
         public double Latitude { get; set; }
-        public int Elevation { get; set; }
+        public int? Elevation { get; set; }
         public int DataStartYear { get; set; }
         public int DataEndYear { get; set; }
         public string Status { get; set; } = default!;

--- a/backend/Models/WeatherStation.cs
+++ b/backend/Models/WeatherStation.cs
@@ -10,7 +10,7 @@
         public string? Description { get; set; }
         public double Longitude { get; set; }
         public double Latitude { get; set; }
-        public int Elevation { get; set; }
+        public int? Elevation { get; set; }
         public int DataStartYear {  get; set; }
         public int DataEndYear { get; set; }
         public string Status { get; set; } = default!;

--- a/backend/Services/WeatherStationService.cs
+++ b/backend/Services/WeatherStationService.cs
@@ -75,7 +75,7 @@ namespace PWAApi.Services
                       Description = el.GetProperty("location_description").GetString(),
                       Longitude = coords[0],
                       Latitude = coords[1],
-                      Elevation = el.GetProperty("elevation").GetInt32(),
+                      Elevation = el.TryGetProperty("elevation", out var elevProp) && elevProp.ValueKind != JsonValueKind.Null ? elevProp.GetInt32() : null,
                       DataStartYear = el.GetProperty("dataStartYear").GetInt32(),
                       DataEndYear = el.GetProperty("dataEndYear").ValueKind == JsonValueKind.Null ? currentYearDate : el.GetProperty("dataEndYear").GetInt32(),
                       Status = el.GetProperty("status").GetString()!

--- a/frontend/source/js/components/ObservationPanel.js
+++ b/frontend/source/js/components/ObservationPanel.js
@@ -60,7 +60,7 @@ export function createObservationPanel(api, toastManager) {
         
         $detailName.text(station.name);
         $detailDescription.text(station.description);
-        $detailElevation.text(station.elevation + "m");
+        $detailElevation.text(station.elevation != null ? station.elevation + "m" : "Not Available");
         $detailStatus.text(station.status);
         $detailLng.text(formattedCoords.lng);
         $detailLat.text(formattedCoords.lat);


### PR DESCRIPTION
Changed the Elevation property in WeatherStation and WeatherStationDto to be nullable to handle cases where elevation data is missing. Updated WeatherStationService to correctly parse nullable elevation from JSON. Modified ObservationPanel.js to display 'Not Available' when elevation is null.