### PR TITLE
Handle HTTP 429 rate limit for downloads

### DIFF
--- a/frontend/source/js/core/toastManager.js
+++ b/frontend/source/js/core/toastManager.js
@@ -25,7 +25,7 @@ export function createToastManager() {
                 left: '50%',
                 transform: 'translateX(-50%)',
                 'z-index': 9999,
-                'max-width': '400px',
+                'max-width': '450px',
                 width: '90%'
             });
 

--- a/frontend/source/js/services/WeatherStationAPI.js
+++ b/frontend/source/js/services/WeatherStationAPI.js
@@ -148,6 +148,9 @@ export function createWeatherStationAPI(baseUrl, toastManager) {
                 });
 
                 if (!response.ok) {
+                    if(response.status === 429){
+                        throw new Error('You have temporarily exceeded the maximum number of downloads allowed. Please wait a moment before continuing.', { cause: 429 });
+                    }
                     throw new Error(`Download failed with status ${response.status}`);
                 }
 
@@ -177,7 +180,8 @@ export function createWeatherStationAPI(baseUrl, toastManager) {
                 window.URL.revokeObjectURL(downloadUrl);
 
             } catch (error) {
-                toastManager.handleError(error, 'downloadFile', 'Failed to download file');
+                const userMessage = error.cause === 429 ? error.message : 'Failed to download file';
+                toastManager.handleError(error, 'downloadFile', userMessage);
             }
         },
 

--- a/wa-infra/charts/frontend/templates/nginx-configmap-frontend.yaml
+++ b/wa-infra/charts/frontend/templates/nginx-configmap-frontend.yaml
@@ -89,6 +89,7 @@ data:
             deny all;
             {{- end }}
             
+            limit_req_status 429;
 
             # Serve static files
             location / {


### PR DESCRIPTION
Detect and surface download rate limiting (HTTP 429): WeatherStationAPI now throws a specific error when a 429 is returned and passes a user-friendly message to toastManager; nginx config is updated to return 429 for rate-limited requests. Also increase toast max-width to 450px to accommodate the longer message.