### PR TITLE
Disable IP restriction for prod frontend

### DIFF
--- a/wa-infra/values-prod.yaml
+++ b/wa-infra/values-prod.yaml
@@ -17,7 +17,7 @@ frontend:
     name: wa-prod-backend
   route:
     host: wa.apps.silver.devops.gov.bc.ca
-    iprestricted: true
+    iprestricted: false
     ipallowlist:
       - "142.34.53.0/24"
       - "142.22.0.0/15"


### PR DESCRIPTION
Set frontend.route.iprestricted to false in wa-infra/values-prod.yaml to stop enforcing the IP allowlist for the production frontend route.